### PR TITLE
Session is lost when user changes his password

### DIFF
--- a/password_policies/tests/test_middleware.py
+++ b/password_policies/tests/test_middleware.py
@@ -45,7 +45,7 @@ class PasswordPoliciesMiddlewareTest(BaseTest):
     def test_password_middleware_with_history(self):
         create_password_history(self.user)
         self.client.login(username='alice', password=passwords[-1])
-        response = self.client.get(reverse('home'))
+        response = self.client.get(reverse('home'), follow=False)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(get_response_location(response['Location']), self.redirect_url)
         self.client.logout()
@@ -53,7 +53,7 @@ class PasswordPoliciesMiddlewareTest(BaseTest):
 
     def test_password_middleware_enforced_redirect(self):
         self.client.login(username='alice', password=passwords[-1])
-        response = self.client.get(reverse('home'))
+        response = self.client.get(reverse('home'), follow=False)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(get_response_location(response['Location']), self.redirect_url)
         self.client.logout()
@@ -65,7 +65,7 @@ class PasswordPoliciesMiddlewareTest(BaseTest):
         self.user.save()
         p = PasswordChangeRequired.objects.create(user=self.user)
         self.client.login(username='alice', password=passwords[-1])
-        response = self.client.get(reverse('home'))
+        response = self.client.get(reverse('home'), follow=False)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(get_response_location(response['Location']), self.redirect_url)
         self.client.logout()

--- a/password_policies/views.py
+++ b/password_policies/views.py
@@ -1,6 +1,7 @@
 from django.utils import timezone
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import get_user_model
+from django.contrib.auth import update_session_auth_hash
 from django.core import signing
 try:
     from django.core.urlresolvers import reverse
@@ -79,6 +80,9 @@ A view that allows logged in users to change their password.
 
     def form_valid(self, form):
         form.save()
+        # Updating the password logs out all other sessions for the user
+        # except the current one.
+        update_session_auth_hash(self.request, form.user)
         return super(PasswordChangeFormView, self).form_valid(form)
 
     def get_form(self, form_class=None):


### PR DESCRIPTION
When a user changes his password, the session is lost for all users, the one who changes the password but also the others logged into de system.
this pull request fix this problem taking the same approach than `auth.view.py PasswordChangeView`:
[django.contrib.auth.views.PasswordChangeView](https://docs.djangoproject.com/en/3.1/topics/auth/default/#django.contrib.auth.views.PasswordChangeView)