### PR TITLE
Support Django 2.2 LTS again

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ As for now (Jan 2021), this fork is actively maintained by |iplweb|
 Requirements
 =============
 
-This application requires `Django`_ 3.0 or newer
+This application requires `Django`_ 2.2 or newer
 
 .. _documentation:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-django>=3.0
+django>=2.2


### PR DESCRIPTION
Since Django 2.2 is the latest LTS version, it seems reasonable to keep the support, at least until next 3.2 LTS is released