### PR TITLE
added safety checks to context processor

### DIFF
--- a/password_policies/context_processors.py
+++ b/password_policies/context_processors.py
@@ -1,5 +1,15 @@
 from password_policies.models import PasswordHistory
 
+def _authenticated (request):
+    if not hasattr(request, 'user'):
+        return False
+    if not request.user:
+        return False
+    try:
+        # Django 1.9 backwards compatibility
+        return request.user.is_authenticated()
+    except TypeError:
+        return request.user.is_authenticated
 
 def password_status(request):
     """
@@ -24,13 +34,7 @@ in a project's settings file::
     )
 """
     d = {}
-    try:
-        # Did this ever worked? It gives error on Django 2.0
-        # and I haven't ran the test suite before that...
-        auth = request.user.is_authenticated()
-    except TypeError:
-        auth = request.user.is_authenticated
-    if auth:
+    if _authenticated(request):
         if '_password_policies_change_required' not in request.session:
             r = PasswordHistory.objects.change_required(request.user)
         else:


### PR DESCRIPTION
I added some safety checks to prevent this context processor from raising an unnecessary exception.
rest_framework can set user = None
django.contrib.auth.context_processors.auth is okay with that as long as an attribute exists