### PR TITLE
added admin:logout to PasswordChangeMiddleware and enabled userlinks in django-password-policies views

### DIFF
--- a/password_policies/middleware.py
+++ b/password_policies/middleware.py
@@ -145,6 +145,12 @@ class PasswordChangeMiddleware(MiddlewareMixin):
                 pass
             else:
                 paths.append(r"^%s$" % logout_url)
+            try:
+                logout_url = reverse("admin:logout")
+            except NoReverseMatch:
+                pass
+            else:
+                paths.append(r"^%s$" % logout_url)
         for path in paths:
             if re.match(path, actual_path):
                 return True

--- a/password_policies/views.py
+++ b/password_policies/views.py
@@ -45,20 +45,7 @@ class LoggedOutMixin(View):
         return super(LoggedOutMixin, self).dispatch(request, *args, **kwargs)
 
 
-class UserlinksVisibilityContextMixin(object):
-
-    def get_context_data(self, **kwargs):
-        """
-        Adds `has_permission` variable to the view's context
-        used by base.html to check if userlinks (e.g. logout link)
-        could be displayed"""
-        kwargs.update({
-            'has_permission': self.request.user.is_active and self.request.user.is_staff,
-        })
-        return super(UserlinksVisibilityContextMixin, self).get_context_data(**kwargs)
-
-
-class PasswordChangeDoneView(UserlinksVisibilityContextMixin, TemplateView):
+class PasswordChangeDoneView(TemplateView):
     """
     A view to redirect to after a successfull change of a user's password."""
 
@@ -72,7 +59,7 @@ class PasswordChangeDoneView(UserlinksVisibilityContextMixin, TemplateView):
         return super(PasswordChangeDoneView, self).dispatch(*args, **kwargs)
 
 
-class PasswordChangeFormView(UserlinksVisibilityContextMixin, FormView):
+class PasswordChangeFormView(FormView):
     """
     A view that allows logged in users to change their password."""
 
@@ -138,7 +125,7 @@ class PasswordChangeFormView(UserlinksVisibilityContextMixin, FormView):
         return super(PasswordChangeFormView, self).get_context_data(**kwargs)
 
 
-class PasswordResetCompleteView(UserlinksVisibilityContextMixin, LoggedOutMixin, TemplateView):
+class PasswordResetCompleteView(LoggedOutMixin, TemplateView):
     """
     A view to redirect to after a password reset has been successfully
     confirmed."""
@@ -227,7 +214,7 @@ class PasswordResetConfirmView(LoggedOutMixin, FormView):
         return self.render_to_response(self.get_context_data())
 
 
-class PasswordResetDoneView(UserlinksVisibilityContextMixin, LoggedOutMixin, TemplateView):
+class PasswordResetDoneView(LoggedOutMixin, TemplateView):
     """
     A view to redirect to after a password reset has been requested."""
 
@@ -237,7 +224,7 @@ class PasswordResetDoneView(UserlinksVisibilityContextMixin, LoggedOutMixin, Tem
     template_name = "registration/password_reset_done.html"
 
 
-class PasswordResetFormView(UserlinksVisibilityContextMixin, LoggedOutMixin, FormView):
+class PasswordResetFormView(LoggedOutMixin, FormView):
     """
     A view that allows registered users to change their password."""
 

--- a/password_policies/views.py
+++ b/password_policies/views.py
@@ -122,6 +122,10 @@ class PasswordChangeFormView(FormView):
     def get_context_data(self, **kwargs):
         name = self.redirect_field_name
         kwargs[name] = self.request.GET.get(name, "")
+        kwargs.update({
+            #: `has_permission` variable is used by base.html to check if userlinks(e.g. logout link) could be displayed
+            'has_permission': self.request.user.is_active and self.request.user.is_staff,
+        })
         return super(PasswordChangeFormView, self).get_context_data(**kwargs)
 
 

--- a/password_policies/views.py
+++ b/password_policies/views.py
@@ -45,7 +45,20 @@ class LoggedOutMixin(View):
         return super(LoggedOutMixin, self).dispatch(request, *args, **kwargs)
 
 
-class PasswordChangeDoneView(TemplateView):
+class UserlinksVisibilityContextMixin(object):
+
+    def get_context_data(self, **kwargs):
+        """
+        Adds `has_permission` variable to the view's context
+        used by base.html to check if userlinks (e.g. logout link)
+        could be displayed"""
+        kwargs.update({
+            'has_permission': self.request.user.is_active and self.request.user.is_staff,
+        })
+        return super(UserlinksVisibilityContextMixin, self).get_context_data(**kwargs)
+
+
+class PasswordChangeDoneView(UserlinksVisibilityContextMixin, TemplateView):
     """
     A view to redirect to after a successfull change of a user's password."""
 
@@ -59,7 +72,7 @@ class PasswordChangeDoneView(TemplateView):
         return super(PasswordChangeDoneView, self).dispatch(*args, **kwargs)
 
 
-class PasswordChangeFormView(FormView):
+class PasswordChangeFormView(UserlinksVisibilityContextMixin, FormView):
     """
     A view that allows logged in users to change their password."""
 
@@ -122,14 +135,10 @@ class PasswordChangeFormView(FormView):
     def get_context_data(self, **kwargs):
         name = self.redirect_field_name
         kwargs[name] = self.request.GET.get(name, "")
-        kwargs.update({
-            #: `has_permission` variable is used by base.html to check if userlinks(e.g. logout link) could be displayed
-            'has_permission': self.request.user.is_active and self.request.user.is_staff,
-        })
         return super(PasswordChangeFormView, self).get_context_data(**kwargs)
 
 
-class PasswordResetCompleteView(LoggedOutMixin, TemplateView):
+class PasswordResetCompleteView(UserlinksVisibilityContextMixin, LoggedOutMixin, TemplateView):
     """
     A view to redirect to after a password reset has been successfully
     confirmed."""
@@ -218,7 +227,7 @@ class PasswordResetConfirmView(LoggedOutMixin, FormView):
         return self.render_to_response(self.get_context_data())
 
 
-class PasswordResetDoneView(LoggedOutMixin, TemplateView):
+class PasswordResetDoneView(UserlinksVisibilityContextMixin, LoggedOutMixin, TemplateView):
     """
     A view to redirect to after a password reset has been requested."""
 
@@ -228,7 +237,7 @@ class PasswordResetDoneView(LoggedOutMixin, TemplateView):
     template_name = "registration/password_reset_done.html"
 
 
-class PasswordResetFormView(LoggedOutMixin, FormView):
+class PasswordResetFormView(UserlinksVisibilityContextMixin, LoggedOutMixin, FormView):
     """
     A view that allows registered users to change their password."""
 


### PR DESCRIPTION
- added admin:logout to PasswordChangeMiddleware 
- enabled userlinks(e.g. logout link) in admin header (see attached screenshot) for every django-password-policies views

![Screenshot 2021-07-09 at 20 18 29](https://user-images.githubusercontent.com/2088831/125121332-10987100-e0f4-11eb-8561-36a54f355419.png)


