### PR TITLE
Feature/json session serializer

### DIFF
--- a/docs/topics/setup.rst
+++ b/docs/topics/setup.rst
@@ -195,10 +195,10 @@ file::
 Serializer
 ============================
 
-For now this app uses the PickleSerializer. This needs to be set up in the Django settings
-file::
+This app is tested with both PickleSerializer and JsonSerializer.
 
-    SESSION_SERIALIZER='django.contrib.sessions.serializers.PickleSerializer'
+Django recommends to change from old pickle serializer to json because
+possible remote code execution vulnerability.
 
 .. _setup-create-db-tables:
 

--- a/password_policies/conf/settings.py
+++ b/password_policies/conf/settings.py
@@ -184,3 +184,8 @@ TEMPLATE_403_PAGE = getattr(settings, "TEMPLATE_403_PAGE", "403.html")
 
 
 PASSWORD_RESET_TIMEOUT_DAYS = 1
+
+PASSWORD_POLICIES_LAST_CHECKED_SESSION_KEY = "_password_policies_last_checked"
+PASSWORD_POLICIES_EXPIRED_SESSION_KEY = "_password_policies_expired"
+PASSWORD_POLICIES_LAST_CHANGED_SESSION_KEY = "_password_policies_last_changed"
+PASSWORD_POLICIES_CHANGE_REQUIRED_SESSION_KEY = "_password_policies_change_required"

--- a/password_policies/context_processors.py
+++ b/password_policies/context_processors.py
@@ -1,3 +1,4 @@
+from password_policies.conf import settings
 from password_policies.models import PasswordHistory
 
 
@@ -31,9 +32,9 @@ in a project's settings file::
     except TypeError:
         auth = request.user.is_authenticated
     if auth:
-        if '_password_policies_change_required' not in request.session:
+        if settings.PASSWORD_POLICIES_CHANGE_REQUIRED_SESSION_KEY not in request.session:
             r = PasswordHistory.objects.change_required(request.user)
         else:
-            r = request.session['_password_policies_change_required']
+            r = request.session[settings.PASSWORD_POLICIES_CHANGE_REQUIRED_SESSION_KEY]
         d['password_change_required'] = r
     return d

--- a/password_policies/middleware.py
+++ b/password_policies/middleware.py
@@ -100,7 +100,7 @@ class PasswordChangeMiddleware(MiddlewareMixin):
             #  tell by self.now time having just been set.
         if (
             not settings.PASSWORD_CHECK_ONLY_AT_LOGIN
-            or request.session.get(self.checked, None) == self.now
+            or request.session.get(self.checked, None) == datetime_to_string(self.now)
         ):
             # If a password change is enforced we won't check
             # the user's password history, thus reducing DB hits...

--- a/password_policies/middleware.py
+++ b/password_policies/middleware.py
@@ -20,7 +20,6 @@ from password_policies.conf import settings
 from password_policies.models import PasswordChangeRequired, PasswordHistory
 from password_policies.utils import PasswordCheck, string_to_datetime, datetime_to_string
 
-
 class PasswordChangeMiddleware(MiddlewareMixin):
     """
     A middleware to force a password change.
@@ -68,10 +67,10 @@ class PasswordChangeMiddleware(MiddlewareMixin):
         This middleware does not try to redirect using the HTTPS
         protocol."""
 
-    checked = "_password_policies_last_checked"
-    expired = "_password_policies_expired"
-    last = "_password_policies_last_changed"
-    required = "_password_policies_change_required"
+    checked = settings.PASSWORD_POLICIES_LAST_CHECKED_SESSION_KEY
+    expired = settings.PASSWORD_POLICIES_EXPIRED_SESSION_KEY
+    last = settings.PASSWORD_POLICIES_LAST_CHANGED_SESSION_KEY
+    required = settings.PASSWORD_POLICIES_CHANGE_REQUIRED_SESSION_KEY
     td = timedelta(seconds=settings.PASSWORD_DURATION_SECONDS)
 
     def _check_history(self, request):

--- a/password_policies/tests/test_middleware.py
+++ b/password_policies/tests/test_middleware.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     from django.urls.base import reverse
 
+from django.test.utils import override_settings
 from django.utils import timezone
 
 from password_policies.conf import settings
@@ -29,6 +30,52 @@ def get_response_location(location):
 
 
 class PasswordPoliciesMiddlewareTest(TestCase):
+    def setUp(self):
+        self.user = create_user()
+        self.redirect_url = "http://testserver/password/change/?next=/"
+
+    def test_password_middleware_without_history(self):
+        seconds = settings.PASSWORD_DURATION_SECONDS - 60
+        self.user.date_joined = get_datetime_from_delta(timezone.now(), seconds)
+        self.user.last_login = get_datetime_from_delta(timezone.now(), seconds)
+        self.user.save()
+        self.client.login(username="alice", password=passwords[-1])
+        response = self.client.get(reverse("home"))
+        self.assertEqual(response.status_code, 200)
+        self.client.logout()
+
+    def test_password_middleware_with_history(self):
+        create_password_history(self.user)
+        self.client.login(username="alice", password=passwords[-1])
+        response = self.client.get(reverse("home"), follow=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(get_response_location(response["Location"]), self.redirect_url)
+        self.client.logout()
+        PasswordHistory.objects.filter(user=self.user).delete()
+
+    def test_password_middleware_enforced_redirect(self):
+        self.client.login(username="alice", password=passwords[-1])
+        response = self.client.get(reverse("home"), follow=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(get_response_location(response["Location"]), self.redirect_url)
+        self.client.logout()
+
+    def test_password_change_required_enforced_redirect(self):
+        seconds = settings.PASSWORD_DURATION_SECONDS - 60
+        self.user.date_joined = get_datetime_from_delta(timezone.now(), seconds)
+        self.user.last_login = get_datetime_from_delta(timezone.now(), seconds)
+        self.user.save()
+        p = PasswordChangeRequired.objects.create(user=self.user)
+        self.client.login(username="alice", password=passwords[-1])
+        response = self.client.get(reverse("home"), follow=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(get_response_location(response["Location"]), self.redirect_url)
+        self.client.logout()
+        p.delete()
+
+
+@override_settings(SESSION_SERIALIZER='django.contrib.sessions.serializers.JSONSerializer')
+class PasswordPoliciesMiddlewareJsonSerializerTest(TestCase):
     def setUp(self):
         self.user = create_user()
         self.redirect_url = "http://testserver/password/change/?next=/"

--- a/password_policies/tests/test_settings.py
+++ b/password_policies/tests/test_settings.py
@@ -84,4 +84,5 @@ MIDDLEWARE = (
 
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 
+
 MEDIA_URL = "/media/somewhere/"

--- a/password_policies/utils.py
+++ b/password_policies/utils.py
@@ -1,6 +1,7 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 from django.utils import timezone
+from django.conf import settings as django_settings
 from django.core.exceptions import ObjectDoesNotExist
 
 from password_policies.conf import settings
@@ -46,3 +47,29 @@ exists the verification is successful.
         "Returns the date and time when the user's password has expired."
         seconds = settings.PASSWORD_DURATION_SECONDS
         return timezone.now() - timedelta(seconds=seconds)
+
+def datetime_to_string(value, format=None):
+    """ Transform datetime object in a string with input format
+:returns: formatted datetime
+:rtype: str
+"""
+    if format is None:
+        format = "%Y-%m-%dT%H:%M:%S.%f%z" if django_settings.USE_TZ else "%Y-%m-%dT%H:%M:%S.%f"
+
+    if not isinstance(value, str):
+        return datetime.strftime(value, format)
+    else:
+        return value
+
+def string_to_datetime(value, format=None):
+    """ Transform string object in a datetime with input format
+:returns: formatted string
+:rtype: datetime
+"""
+    if format is None:
+        format = "%Y-%m-%dT%H:%M:%S.%f%z" if django_settings.USE_TZ else "%Y-%m-%dT%H:%M:%S.%f"
+
+    if not isinstance(value, datetime):
+        return datetime.strptime(value, format)
+    else:
+        return value

--- a/password_policies/views.py
+++ b/password_policies/views.py
@@ -27,7 +27,7 @@ from password_policies.forms import (
     PasswordPoliciesForm,
     PasswordResetForm,
 )
-
+from password_policies.utils import string_to_datetime, datetime_to_string
 
 class LoggedOutMixin(View):
     """
@@ -107,8 +107,10 @@ class PasswordChangeFormView(FormView):
         last = "_password_policies_last_changed"
         required = "_password_policies_change_required"
         now = timezone.now()
-        self.request.session[checked] = now
-        self.request.session[last] = now
+        now_str = datetime_to_string(now)
+
+        self.request.session[checked] = now_str
+        self.request.session[last] = now_str
         self.request.session[required] = False
         redirect_to = self.request.POST.get(self.redirect_field_name, "")
         if redirect_to:

--- a/password_policies/views.py
+++ b/password_policies/views.py
@@ -103,9 +103,9 @@ class PasswordChangeFormView(FormView):
         user was requesting before the password change.)
         If not returns the :attr:`~PasswordChangeFormView.success_url` attribute
         if set, otherwise the URL to the :class:`PasswordChangeDoneView`."""
-        checked = "_password_policies_last_checked"
-        last = "_password_policies_last_changed"
-        required = "_password_policies_change_required"
+        checked = settings.PASSWORD_POLICIES_LAST_CHECKED_SESSION_KEY
+        last = settings.PASSWORD_POLICIES_LAST_CHANGED_SESSION_KEY
+        required = settings.PASSWORD_POLICIES_CHANGE_REQUIRED_SESSION_KEY
         now = timezone.now()
         now_str = datetime_to_string(now)
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@ from setuptools import find_packages, setup
 
 install_requires = ["django"]
 
+tests_require = [
+    'freezegun',
+]
+
 setup(
     name="django-password-policies-iplweb",
     version=__import__("password_policies").__version__,
@@ -32,5 +36,6 @@ and a mechanism to force password changes.
         "Topic :: Utilities",
     ],
     install_requires=install_requires,
+    tests_require=tests_require,
     test_suite="tests.runtests",
 )


### PR DESCRIPTION
Django recommends to change from old pickle serializer to json because possible remote code execution vulnerability([django docs](https://docs.djangoproject.com/en/2.2/topics/http/sessions/#session-serialization)).

Can we switch this lib too?

This PR enables the use of JsonSerializer(Django default serializer). 
To do this, we set datetimes as strings, as the datetimes are not json-serializable natively. 

We have added some tests to verify that it works even with USE_TZ=False and to verify that the middleware continues to work.

To switch from PickleSerializer to JsonSerializer, active sessions need to be cleared (python manage.py clearsessions).

Hope it helps