### PR TITLE
fix context processor

### DIFF
--- a/password_policies/context_processors.py
+++ b/password_policies/context_processors.py
@@ -1,6 +1,20 @@
 from password_policies.models import PasswordHistory
 
 
+def _authenticated(request):
+    """ helper function to check request for an authenticated user """
+
+    if not hasattr(request, 'user'):
+        return False
+    if not request.user:
+        return False
+    try:
+        # Django 1.9 backwards compatibility
+        return request.user.is_authenticated()
+    except TypeError:
+        return request.user.is_authenticated
+
+
 def password_status(request):
     """
 Adds a variable determining the state of a user's password
@@ -24,13 +38,7 @@ in a project's settings file::
     )
 """
     d = {}
-    try:
-        # Did this ever worked? It gives error on Django 2.0
-        # and I haven't ran the test suite before that...
-        auth = request.user.is_authenticated()
-    except TypeError:
-        auth = request.user.is_authenticated
-    if auth:
+    if _authenticated(request):
         if '_password_policies_change_required' not in request.session:
             r = PasswordHistory.objects.change_required(request.user)
         else:

--- a/password_policies/tests/test_context_processors.py
+++ b/password_policies/tests/test_context_processors.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from django.http import HttpRequest
+from password_policies.context_processors import password_status
+
+class ContextProcessorsTests(TestCase):
+
+    def test_password_status(self):
+        request = HttpRequest()
+        request.user = None
+        try:
+            self.assertEqual({}, password_status(request))
+        except:
+            self.fail("unhandled exception in password_status")


### PR DESCRIPTION
In some unusual cases (which are probably poor practice on their own) the context_processors in password_policies can raise an exception, preventing other handlers from handling the real exception.

Ideally, we don't want password_policies making that situation worse, so I added some safety checks, and have introduced a unit test for the context_processors.py to validate these changes.