### PR TITLE
add apps.py to avoid warnings on system check

### DIFF
--- a/password_policies/apps.py
+++ b/password_policies/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+class PasswordPoliciesConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
+    name = 'password_policies'
+


### PR DESCRIPTION
Hi, when I run the tests with python 3.9 and Django 3.2, I get the following warnings.

```
System check identified some issues:

WARNINGS:
password_policies.PasswordChangeRequired: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
password_policies.PasswordHistory: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
password_policies.PasswordProfile: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```

So, in order to avoid those warnings I followed the recommendations at the official django documentation.
https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys

I need to get this running without these Warnings, so it makes my Django 3.2 CI up and running.

It seems to me that the least intrusive way of fixing this is adding the default_auto_field attribute to the PasswordPoliciesConfig inside the apps.py to point to 'django.db.models.AutoField' or maybe even BigAutoField. Since existing projects use AutoField, I am tending to this one to not cause new migrations for all existing projects.

This fix implement this.
