### PR TITLE
remove deprecated non-integer input to randrange()

### DIFF
--- a/password_policies/tests/lib.py
+++ b/password_policies/tests/lib.py
@@ -46,7 +46,7 @@ def create_user(
     if not raw_password:
         raw_password = passwords[-1]
     if not date_joined:
-        rind = randint(0, (duration / count + 1))
+        rind = randint(0, (duration // count + 1))
         seconds = (count * duration + rind) * 2
         date_joined = get_datetime_from_delta(timezone.now(), seconds)
     if not last_login:


### PR DESCRIPTION
Replace float division with integer division in `create_user()` to ensure integer input to `randint()`, which internally calls `randrange()`. Non-integer inputs to `randrange()` has been deprecated in Python 3.10, and will be removed in a future version.

This change also addresses the corresponding python warnings that would appear in the client code that uses the `create_user()` method.