### PR TITLE
Add verbose name

### DIFF
--- a/password_policies/apps.py
+++ b/password_policies/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class PasswordPoliciesConfig(AppConfig):
     name = "password_policies"
+    verbose_name = "Password Policies"


### PR DESCRIPTION
Setting [verbose_name](https://docs.djangoproject.com/en/5.1/ref/applications/#django.apps.AppConfig.verbose_name) updates the application name in the admin interface to remove the underscore.

Before:
![image](https://github.com/user-attachments/assets/c45b1f46-4470-4ea4-8f12-348320004eea)

After:
![image](https://github.com/user-attachments/assets/4e5bc363-f399-403f-a2ce-5bfa115f6a84)
