### PR TITLE
Remove help_text from email field

### DIFF
--- a/password_policies/forms/__init__.py
+++ b/password_policies/forms/__init__.py
@@ -193,8 +193,12 @@ class PasswordResetForm(forms.Form):
             "address cannot reset the password."
         ),
     }
-    # TODO: Help text?
-    email = forms.EmailField(label=_("E-mail"), max_length=75, help_text="help")
+
+    email = forms.EmailField(
+        label=_("E-mail"),
+        max_length=75,
+        widget=forms.EmailInput(attrs={"autocomplete": "email"}),
+    )
 
     def clean_email(self):
         """


### PR DESCRIPTION
Removes random "help" `help_text` attribute from email field and adds autocomplete to bring it more inline with Django's [auth email field](https://github.com/django/django/blob/438fc42ac667653488200578a47e59f6608f2b0b/django/contrib/auth/forms.py#L395).
Fixes #43